### PR TITLE
CHG: remove more compiler warnings on UBUNTU14.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 all:
 	gcc -O3 craptev1-v1.0/solve.c -fPIC -shared -o solve.so
-	gcc -O3 -mpopcnt -std=c99 solve_bs.c crypto1_bs.c crypto1_bs_crack.c -Icraptev1-v1.0 craptev1-v1.0/craptev1.c crapto1-v3.3/crapto1.c ./solve.so -o solve_bs -lpthread
-	gcc -O3 -mpopcnt -std=c99 solve_piwi_bs.c crypto1_bs.c crypto1_bs_crack.c -Icraptev1-v1.0 craptev1-v1.0/craptev1.c crapto1-v3.3/crapto1.c -o solve_piwi_bs -lpthread
-	gcc -O3 -mpopcnt solve_piwi.c -I craptev1-v1.0 craptev1-v1.0/craptev1.c -o solve_piwi -lpthread
+	gcc -O3 -mpopcnt -mmmx -std=c99 solve_bs.c crypto1_bs.c crypto1_bs_crack.c -Icraptev1-v1.0 craptev1-v1.0/craptev1.c crapto1-v3.3/crapto1.c ./solve.so -o solve_bs -lpthread
+	gcc -O3 -mpopcnt -mmmx -std=c99 solve_piwi_bs.c crypto1_bs.c crypto1_bs_crack.c -Icraptev1-v1.0 craptev1-v1.0/craptev1.c crapto1-v3.3/crapto1.c -o solve_piwi_bs -lpthread
+	gcc -O3 -mpopcnt -mmmx solve_piwi.c -I craptev1-v1.0 craptev1-v1.0/craptev1.c -o solve_piwi -lpthread
 
 clean:
 	rm solve.so solve_bs solve_piwi_bs solve_piwi

--- a/solve_bs.c
+++ b/solve_bs.c
@@ -26,7 +26,7 @@ void* crack_states_thread(void* x){
     for(j = thread_id; space[j * 5]; j += thread_count) {
         const uint64_t key = crack_states_bitsliced(space + j * 5);
         if(key != -1){
-            printf("Found key: %012lx\n", key);
+            printf("Found key: %012"llx"\n", key);
             __sync_fetch_and_add(&keys_found, 1);
             break;
         } else if(keys_found){


### PR DESCRIPTION
   by::  string.format specifier lx -> "llx"
   by::  adding -mmmx parameter to gcc in makefile.  Thanks to @rbubba1911