### PR TITLE
Display cracking progress in solve_bs and port to OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+craptev1-v1.1.tar.xz
+craptev1-v1.1/*
+crapto1-v3.3.tar.xz
+crapto1-v3.3/*

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,8 @@ CRAPTEV1 = craptev1-v1.1/craptev1.c -I craptev1-v1.1/
 CRAPTO1 = crapto1-v3.3/crapto1.c crapto1-v3.3/crypto1.c -I crapto1-v3.3/ 
 CRYPTO1_BS = crypto1_bs.c crypto1_bs_crack.c 
 
-solve.so:
-	$(CC) $(CFLAGS) craptev1-v1.1/solve.c -fPIC -shared -o solve.so
-
-solve_bs: solve.so
-	$(CC) $(CFLAGS) $@.c $(CRYPTO1_BS) $(CRAPTO1) ${CRAPTEV1} ./solve.so -o $@ -lpthread
+solve_bs:
+	$(CC) $(CFLAGS) $@.c $(CRYPTO1_BS) $(CRAPTO1) ${CRAPTEV1} -o $@ -lpthread
 
 solve_piwi_bs:
 	$(CC) $(CFLAGS) $@.c $(CRYPTO1_BS) $(CRAPTO1) ${CRAPTEV1} -o $@ -lpthread

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ CRAPTO1 = crapto1-v3.3/crapto1.c crapto1-v3.3/crypto1.c -I crapto1-v3.3/
 CRYPTO1_BS = crypto1_bs.c crypto1_bs_crack.c 
 
 solve_bs:
-	$(CC) $(CFLAGS) $@.c $(CRYPTO1_BS) $(CRAPTO1) ${CRAPTEV1} -o $@ -lpthread
+	$(CC) $(CFLAGS) $@.c $(CRYPTO1_BS) $(CRAPTO1) ${CRAPTEV1} -o $@ -lpthread -lm
 
 solve_piwi_bs:
-	$(CC) $(CFLAGS) $@.c $(CRYPTO1_BS) $(CRAPTO1) ${CRAPTEV1} -o $@ -lpthread
+	$(CC) $(CFLAGS) $@.c $(CRYPTO1_BS) $(CRAPTO1) ${CRAPTEV1} -o $@ -lpthread -lm
 
 solve_piwi:
 	$(CC) $(CFLAGS) $@.c $(CRYPTO1_BS) $(CRAPTO1) ${CRAPTEV1} -o $@ -lpthread

--- a/crypto1_bs_crack.c
+++ b/crypto1_bs_crack.c
@@ -136,11 +136,13 @@ inline uint64_t crack_states_bitsliced(uint32_t **task){
                 }
             }
 
-#ifdef EXACT_COUNT
             // Fix a "1000000% bug". Looks like here is a problem with OS X gcc
-            bucket_states_tested += bucket_size[block_idx] > MAX_BITSLICES ? MAX_BITSLICES : bucket_size[block_idx];
+            size_t current_bucket_size = bucket_size[block_idx] > MAX_BITSLICES ? MAX_BITSLICES : bucket_size[block_idx];
+
+#ifdef EXACT_COUNT
+            bucket_states_tested += current_bucket_size;
 #ifdef ONLINE_COUNT
-            __atomic_fetch_add(&total_states_tested, bucket_size[block_idx] > MAX_BITSLICES ? MAX_BITSLICES : bucket_size[block_idx], __ATOMIC_RELAXED);
+            __atomic_fetch_add(&total_states_tested, current_bucket_size, __ATOMIC_RELAXED);
 #endif
 #else
 #ifdef ONLINE_COUNT

--- a/crypto1_bs_crack.c
+++ b/crypto1_bs_crack.c
@@ -23,6 +23,9 @@ THE SOFTWARE.
 */
 
 #include <stdlib.h>
+#ifndef __APPLE__
+#include <malloc.h>
+#endif
 #include "crypto1_bs_crack.h"
 
 inline uint64_t crack_states_bitsliced(uint32_t **task){

--- a/crypto1_bs_crack.c
+++ b/crypto1_bs_crack.c
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include <malloc.h>
+#include <stdlib.h>
 #include "crypto1_bs_crack.h"
 
 inline uint64_t crack_states_bitsliced(uint32_t **task){
@@ -134,9 +134,10 @@ inline uint64_t crack_states_bitsliced(uint32_t **task){
             }
 
 #ifdef EXACT_COUNT
-            bucket_states_tested += bucket_size[block_idx];
+            // Fix a "1000000% bug". Looks like here is a problem with OS X gcc
+            bucket_states_tested += bucket_size[block_idx] > MAX_BITSLICES ? MAX_BITSLICES : bucket_size[block_idx];
 #ifdef ONLINE_COUNT
-            __atomic_fetch_add(&total_states_tested, bucket_size[block_idx], __ATOMIC_RELAXED);
+            __atomic_fetch_add(&total_states_tested, bucket_size[block_idx] > MAX_BITSLICES ? MAX_BITSLICES : bucket_size[block_idx], __ATOMIC_RELAXED);
 #endif
 #else
 #ifdef ONLINE_COUNT

--- a/libnfc_crypto1_crack.c
+++ b/libnfc_crypto1_crack.c
@@ -517,6 +517,7 @@ void * update_predictions_thread(void* p){
         if(space){
             total_states = craptev1_sizeof_space(space);
         }
+        sleep(1); // We don't need to check this more often than once per second
     }
     return NULL;
 }

--- a/libnfc_crypto1_crack.c
+++ b/libnfc_crypto1_crack.c
@@ -288,7 +288,7 @@ POSSIBILITY OF SUCH DAMAGES.
 #include <signal.h>
 #include <pthread.h>
 #include <fcntl.h>
-#include <sys/sysinfo.h>
+#include <unistd.h>
 #include <nfc/nfc.h>
 #include <math.h>
 
@@ -676,7 +676,11 @@ int main (int argc, const char * argv[]) {
         return 1;
     }
 
-    thread_count = get_nprocs_conf();
+#ifndef __WIN32
+    thread_count = sysconf(_SC_NPROCESSORS_CONF);
+#else
+    thread_count = 1;
+#endif
     // append some zeroes to the end of the space to make sure threads don't go off into the wild
     size_t j = 0;
     for(j = 0; space[j]; j+=5){

--- a/solve_bs.c
+++ b/solve_bs.c
@@ -8,6 +8,7 @@
 #include "crypto1_bs.h"
 #include "crypto1_bs_crack.h"
 #include <inttypes.h>
+#include <math.h>
 #define __STDC_FORMAT_MACROS
 #define llx PRIx64
 #define lli PRIi64
@@ -16,7 +17,7 @@
 #define VT100_cleareol "\r\33[2K"
 
 uint32_t **space;
-size_t thread_count = 1;
+uint8_t thread_count = 1;
 
 uint64_t *readnonces(char* fname) {
     int i, j;
@@ -120,7 +121,7 @@ int main(int argc, char* argv[]){
     total_states_tested = 0;
     keys_found = 0;
 
-    printf("Starting %zu threads to test %"llu" states\n", thread_count, total_states);
+    printf("Starting %u threads to test %"llu" (~2^%0.2f) states\n", thread_count, total_states, log(total_states) / log(2));
 
     signal(SIGALRM, notify_status_offline);
     alarm(1);
@@ -134,7 +135,9 @@ int main(int argc, char* argv[]){
 
     alarm(0);
 
-    printf("Tested %"llu" states\n", total_states_tested);
+    printf("\nTested %"llu" states\n", total_states_tested);
+
+    if(!keys_found) fprintf(stderr, "No solution found :(\n");
 
     craptev1_destroy_space(space);
     return 0;

--- a/solve_bs.c
+++ b/solve_bs.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <unistd.h>
+#include <signal.h>
 #include <pthread.h>
 #include "craptev1.h"
 #include "crypto1_bs.h"

--- a/solve_piwi.c
+++ b/solve_piwi.c
@@ -3,9 +3,6 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <pthread.h>
-#ifndef __WIN32
-#include <sys/sysinfo.h>
-#endif
 #include "craptev1.h"
 #include <inttypes.h>
 #define __STDC_FORMAT_MACROS
@@ -74,7 +71,9 @@ int main(int argc, char* argv[]){
     total_states = craptev1_sizeof_space(space);
 
 #ifndef __WIN32
-    thread_count = get_nprocs_conf();
+    thread_count = sysconf(_SC_NPROCESSORS_CONF);
+#else
+    thread_count = 1;
 #endif
     // append some zeroes to the end of the space to make sure threads don't go off into the wild
     size_t j = 0;

--- a/solve_piwi_bs.c
+++ b/solve_piwi_bs.c
@@ -1,12 +1,8 @@
 #include <stdlib.h>
-#include <malloc.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <unistd.h>
 #include <pthread.h>
-#ifndef __WIN32
-#include <sys/sysinfo.h>
-#endif
 #include "craptev1.h"
 #include "crypto1_bs.h"
 #include "crypto1_bs_crack.h"

--- a/solve_piwi_bs.c
+++ b/solve_piwi_bs.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <unistd.h>
+#include <signal.h>
 #include <pthread.h>
 #include "craptev1.h"
 #include "crypto1_bs.h"

--- a/solve_piwi_bs.c
+++ b/solve_piwi_bs.c
@@ -8,6 +8,7 @@
 #include "crypto1_bs.h"
 #include "crypto1_bs_crack.h"
 #include <inttypes.h>
+#include <math.h>
 #define __STDC_FORMAT_MACROS
 #define llx PRIx64
 #define lli PRIi64
@@ -23,6 +24,10 @@ uint32_t uid;
 uint64_t *readnonces(char* fname){
     int i;
     FILE *f = fopen(fname, "rb");
+    if (f == NULL) {
+        fprintf(stderr, "Cannot open file.\n");
+        exit(EXIT_FAILURE);
+    }
     uint64_t *nonces = malloc(sizeof (uint64_t) <<  24);
     if(fread(&uid, 1, 4, f)){
         uid = rev32(uid);
@@ -119,7 +124,7 @@ int main(int argc, char* argv[]){
     total_states_tested = 0;
     keys_found = 0;
 
-    printf("Starting %u threads to test %"llu" states\n", thread_count, total_states);
+    printf("Starting %u threads to test %"llu" (~2^%0.2f) states\n", thread_count, total_states, log(total_states) / log(2));
 
     signal(SIGALRM, notify_status_offline);
     alarm(1);


### PR DESCRIPTION
In OS X there is no `malloc.h`, `sysinfo.h` and  `futex.h`, so I have made some changes.
Also I have add progress display to `solve_bs` like in `libnfc_crypto1_crack`.