### PR TITLE
Fix build without EXACT_COUNT

### DIFF
--- a/crypto1_bs_crack.c
+++ b/crypto1_bs_crack.c
@@ -136,10 +136,10 @@ inline uint64_t crack_states_bitsliced(uint32_t **task){
                 }
             }
 
+#ifdef EXACT_COUNT
             // Fix a "1000000% bug". Looks like here is a problem with OS X gcc
             size_t current_bucket_size = bucket_size[block_idx] > MAX_BITSLICES ? MAX_BITSLICES : bucket_size[block_idx];
 
-#ifdef EXACT_COUNT
             bucket_states_tested += current_bucket_size;
 #ifdef ONLINE_COUNT
             __atomic_fetch_add(&total_states_tested, current_bucket_size, __ATOMIC_RELAXED);


### PR DESCRIPTION
Hello again.
I have noticed one little mistake in my code. We can not build it without the EXACT_COUNT flag.