### PR TITLE
Upgrade txt_bin bin_txt converter from Python 2 to Python 3

### DIFF
--- a/bintotxt.py
+++ b/bintotxt.py
@@ -1,16 +1,18 @@
 import sys
-data = file(sys.argv[1], 'rb').read()
+with open(sys.argv[1], 'rb') as f:
+    data = f.read()
+
 uid = data[0:4]
 
 def parity(x):
-    return ("{0:08b}".format(x).count('1') & 1)
+    return bin(x).count('1') & 1
 
 for idx in range(6, len(data), 9):
     n = data[idx:idx+8]
     p = data[idx+8]
-    nonce_string = [ "%02x" % ord(n[i])
-                      + ('  ' if int(x)^parity(ord(n[i])) else '! ')
-                      for i, x in enumerate(("{0:08b}".format(ord(p))))
-                   ]
-    print ''.join(nonce_string[:4])
-    print ''.join(nonce_string[4:])
+    nonce_string = [
+        "{:02x}".format(n[i]) + ('  ' if int(x) ^ parity(n[i]) else '! ')
+        for i, x in enumerate("{:08b}".format(p))
+    ]
+    print(''.join(nonce_string[:4]))
+    print(''.join(nonce_string[4:]))

--- a/txttobin.py
+++ b/txttobin.py
@@ -1,29 +1,33 @@
 import sys
-data = file(sys.argv[1], 'rb').readlines()
+with open(sys.argv[1], 'rb') as f:
+    data = f.readlines()
 if sys.argv[1].endswith('.txt'):
     uid = sys.argv[1][:-4]
-
 def parity(x):
     return ("{0:08b}".format(x).count('1') & 1)
 
-uid=raw_input("uid> ")
-fp = file(uid+'_generated.bin','wb')
-fp.write(uid.decode('hex')+"\x00"*2)
-bits = 0
-pbits = 0
-for l in data:
-    if bits == 8:
-        fp.write(chr(pbits))
-        bits = 0
-        pbits = 0
-    hexbytes = filter(None, l.strip().split(' '))
-    bits += 4
-    for x in hexbytes:
-        b = int(x.replace('!', ''), 16)
-        p = parity(b)
-        if '!' not in x:
-            p^=1
-        pbits <<= 1
-        pbits |= p
-        fp.write(chr(b))
+uid = input("uid> ")
+uid_bytes = bytes.fromhex(uid)
 
+with open(uid + '_generated.bin', 'wb') as fp:
+    fp.write(uid_bytes + b"\x00" * 2)
+    bits = 0
+    pbits = 0
+    for l in data:
+        if bits == 8:
+            fp.write(bytes([pbits]))
+            bits = 0
+            pbits = 0
+        if isinstance(l, bytes):
+            l = l.decode('utf-8')
+        hexbytes = [x for x in l.strip().split(' ') if x]
+        
+        bits += 4
+        for x in hexbytes:
+            b = int(x.replace('!', ''), 16)
+            p = parity(b)
+            if '!' not in x:
+                p ^= 1
+            pbits <<= 1
+            pbits |= p
+            fp.write(bytes([b]))


### PR DESCRIPTION
Upgraded the converter from Python 2 to Python 3, focusing solely on syntax compatibility without modifying the underlying logic.